### PR TITLE
Organize utils tests by functionality

### DIFF
--- a/tests/test_firebase.py
+++ b/tests/test_firebase.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import importlib.util
+import asyncio
+
+# Provide dummy aiohttp module before loading utils
+sys.modules['aiohttp'] = types.ModuleType('aiohttp')
+sys.modules['aiohttp'].ClientSession = None
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+utils_path = os.path.join(os.path.dirname(__file__), '..', 'custom_components', 'coral_mylo', 'utils.py')
+spec = importlib.util.spec_from_file_location('utils', utils_path)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+    async def json(self):
+        return self._data
+    async def read(self):
+        return b''
+    async def text(self):
+        return ''
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class FakeSession:
+    def __init__(self, response):
+        self._response = response
+    def get(self, *args, **kwargs):
+        return self._response
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+def test_fetch_firebase_download_token(monkeypatch):
+    response = FakeResponse({'downloadTokens': 'dl'})
+    monkeypatch.setattr(utils, 'aiohttp', types.SimpleNamespace(ClientSession=lambda: FakeSession(response)))
+    token = asyncio.run(utils.fetch_firebase_download_token('b', 'p', 'jwt'))
+    assert token == 'dl'
+
+def test_fetch_firebase_download_token_error(monkeypatch):
+    def failing_session():
+        raise Exception('nope')
+    monkeypatch.setattr(utils, 'aiohttp', types.SimpleNamespace(ClientSession=failing_session))
+    assert asyncio.run(utils.fetch_firebase_download_token('b', 'p', 'jwt')) is None

--- a/tests/test_refresh_jwt.py
+++ b/tests/test_refresh_jwt.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import importlib.util
+import asyncio
+
+# Provide dummy aiohttp module before loading utils
+sys.modules['aiohttp'] = types.ModuleType('aiohttp')
+sys.modules['aiohttp'].ClientSession = None
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+utils_path = os.path.join(os.path.dirname(__file__), '..', 'custom_components', 'coral_mylo', 'utils.py')
+spec = importlib.util.spec_from_file_location('utils', utils_path)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+    async def json(self):
+        return self._data
+    async def read(self):
+        return b''
+    async def text(self):
+        return ''
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class FakeSession:
+    def __init__(self, response):
+        self._response = response
+    def post(self, *args, **kwargs):
+        return self._response
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+def test_refresh_jwt_success(monkeypatch):
+    response = FakeResponse({'access_token': 'tok'})
+    monkeypatch.setattr(utils, 'aiohttp', types.SimpleNamespace(ClientSession=lambda: FakeSession(response)))
+    token = asyncio.run(utils.refresh_jwt('r', 'k'))
+    assert token == 'tok'
+
+def test_refresh_jwt_error(monkeypatch):
+    def failing_session():
+        raise Exception('boom')
+    monkeypatch.setattr(utils, 'aiohttp', types.SimpleNamespace(ClientSession=failing_session))
+    assert asyncio.run(utils.refresh_jwt('r', 'k')) is None

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import types
+import importlib.util
+from unittest.mock import patch
+
+# Provide dummy aiohttp module before loading utils
+sys.modules['aiohttp'] = types.ModuleType('aiohttp')
+sys.modules['aiohttp'].ClientSession = None
+
+# Ensure repo root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Load utils without requiring Home Assistant
+utils_path = os.path.join(os.path.dirname(__file__), '..', 'custom_components', 'coral_mylo', 'utils.py')
+spec = importlib.util.spec_from_file_location('utils', utils_path)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+class FakeSocket:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.sent = []
+    def sendall(self, data):
+        self.sent.append(data)
+    def recv(self, bufsize):
+        return self._responses.pop(0) if self._responses else b''
+    def close(self):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+def test_discover_device_id_from_statsd():
+    gauges = {'coral.42.water.temperature': 24.0}
+    with patch.object(utils, 'read_gauges_from_statsd', return_value=gauges):
+        assert utils.discover_device_id_from_statsd('1.2.3.4') == '42'
+    with patch.object(utils, 'read_gauges_from_statsd', return_value={}):
+        assert utils.discover_device_id_from_statsd('1.2.3.4') is None
+
+def test_read_gauges_from_statsd_success():
+    responses = [b"{'coral.1.metric': 1}\nEND"]
+    fake_socket = FakeSocket(responses)
+    with patch('socket.create_connection', return_value=fake_socket):
+        gauges = utils.read_gauges_from_statsd('1.2.3.4')
+    assert gauges == {'coral.1.metric': 1}
+    assert fake_socket.sent == [b'gauges\n']
+
+def test_read_gauges_from_statsd_error():
+    with patch('socket.create_connection', side_effect=OSError):
+        gauges = utils.read_gauges_from_statsd('1.2.3.4')
+    assert gauges == {}
+
+def test_get_statsd_gauge_value(monkeypatch):
+    monkeypatch.setattr(utils, 'read_gauges_from_statsd', lambda ip: {'key': 3})
+    assert utils.get_statsd_gauge_value('1.2.3.4', 'key') == 3
+    assert utils.get_statsd_gauge_value('1.2.3.4', 'missing') is None


### PR DESCRIPTION
## Summary
- split utils tests into separate modules for statsd, auth and firebase helpers
- expand coverage with tests for `get_statsd_gauge_value` and error paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856347d674832aa9c472c252c8dbf9