### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Integrate your **Coral MYLO Pool Camera** (also known as SmartPool MYLO) with Ho
 
 ### Via HACS
 1. Open [HACS](https://hacs.xyz/) in Home Assistant.
-2. Choose **Integrations → + Explore & Download Repositories**.
-3. Search for **Coral Mylo Integration** and install.
+2. From the **Integrations** tab, open the overflow menu (**⋮**) and select **Custom repositories**.
+3. Enter `https://github.com/jakeyr/coral_mylo_ha` as the repository URL and choose **Integration**.
+4. Click **Add**. The repository now appears under integrations.
+5. Select **Coral Mylo Integration** and click **Download** to install it.
 
 ### Manual
 1. Copy the `custom_components/coral_mylo` folder from this repository to `<config>/custom_components/` in your Home Assistant configuration directory.
@@ -48,13 +50,23 @@ The MYLO app authenticates via Apple ID and never exposes the required tokens. T
 These two values will be entered when adding the integration.
 
 ## Adding the Integration
-1. In Home Assistant, navigate to **Settings → Devices & Services → Add Integration**.
-2. Select **Coral Mylo**.
-3. Provide:
-   - **IP Address** of your MYLO (for example `192.168.1.42`)
-   - **API Key** captured from mitmproxy
-   - **Refresh Token** captured from mitmproxy
-4. Submit the form. The integration queries the MYLO's StatsD service to discover the device ID and then creates the camera and sensor entities.
+Instead of using the Home Assistant config flow, you can define the connection manually in `configuration.yaml`:
+
+```yaml
+coral_mylo:
+  ip: 192.168.1.42
+  api_key: !secret mylo_api_key
+  refresh_token: !secret mylo_refresh_token
+```
+
+Add your actual credentials to `secrets.yaml` in the same directory:
+
+```yaml
+mylo_api_key: YOUR_API_KEY
+mylo_refresh_token: YOUR_REFRESH_TOKEN
+```
+
+Save both files and restart Home Assistant. The integration will start with the camera and sensor entities configured from these values.
 
 ## Entities Created
 - `camera.mylo_camera_<id>` – shows the most recent snapshot taken by the MYLO.


### PR DESCRIPTION
## Summary
- expand HACS install directions to include adding this repo as a custom repository
- document manual configuration via `configuration.yaml`
- recommend storing API credentials in `secrets.yaml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885aedaf418832a9ca4cbd29fd47d92