### PR TITLE
Add snapshot refresh button entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Integrate your **Coral MYLO Pool Camera** (also known as SmartPool MYLO) with Ho
 
 ## Features
 - **Camera** entity displaying the most recent MYLO image
+- **Button** to manually refresh the snapshot
 - **Sensors** for key pool and weather values collected by MYLO:
   - Water temperature (`°C`)
   - Water level (`cm`)
@@ -58,6 +59,7 @@ These two values will be entered when adding the integration.
 
 ## Entities Created
 - `camera.mylo_camera_<id>` – shows the most recent snapshot taken by the MYLO.
+- `button.mylo_refresh_snapshot` – manually refresh the current snapshot.
 - `sensor.mylo_water_temperature` – pool water temperature.
 - `sensor.mylo_water_level` – measured distance from camera to water surface.
 - `sensor.mylo_wind_speed` – outdoor wind speed near the pool.

--- a/custom_components/coral_mylo/__init__.py
+++ b/custom_components/coral_mylo/__init__.py
@@ -11,11 +11,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera"])
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera", "button"])
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor", "camera"])
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor", "camera", "button"])
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/custom_components/coral_mylo/button.py
+++ b/custom_components/coral_mylo/button.py
@@ -1,0 +1,42 @@
+import logging
+from homeassistant.components.button import ButtonEntity
+
+from .const import CONF_IP_ADDRESS, CONF_REFRESH_TOKEN, CONF_API_KEY
+from .utils import (
+    download_latest_snapshot,
+    discover_device_id_from_statsd,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    ip = entry.data[CONF_IP_ADDRESS]
+    refresh_token = entry.data[CONF_REFRESH_TOKEN]
+    api_key = entry.data[CONF_API_KEY]
+
+    device_id = await hass.async_add_executor_job(discover_device_id_from_statsd, ip)
+    if not device_id:
+        _LOGGER.error("Could not discover device ID for button")
+        return
+
+    async_add_entities([MyloSnapshotRefreshButton(refresh_token, api_key, device_id)])
+
+
+class MyloSnapshotRefreshButton(ButtonEntity):
+    """Button to manually refresh the MYLO snapshot."""
+
+    def __init__(self, refresh_token, api_key, device_id):
+        self._refresh_token = refresh_token
+        self._api_key = api_key
+        self._device_id = device_id
+        self._attr_name = "Refresh MYLO Snapshot"
+        self._attr_unique_id = f"mylo_refresh_snapshot_{device_id}"
+
+    async def async_press(self) -> None:
+        await self._refresh_snapshot()
+
+    async def _refresh_snapshot(self):
+        await download_latest_snapshot(
+            self._device_id, self._refresh_token, self._api_key
+        )

--- a/custom_components/coral_mylo/camera.py
+++ b/custom_components/coral_mylo/camera.py
@@ -1,7 +1,9 @@
 import logging
-import aiohttp
 from homeassistant.components.camera import Camera
-from .utils import refresh_jwt, discover_device_id_from_statsd, fetch_firebase_download_token
+from .utils import (
+    discover_device_id_from_statsd,
+    download_latest_snapshot,
+)
 from .const import CONF_IP_ADDRESS, CONF_REFRESH_TOKEN, CONF_API_KEY
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,32 +33,6 @@ class MyloCamera(Camera):
         self._attr_unique_id = f"mylo_camera_{device_id}"
 
     async def async_camera_image(self, **kwargs):
-        bucket = "coralesto.appspot.com"
-        image_path = f"images%2Fcoral_{self._device_id}_last.jpg"
-        jwt = await refresh_jwt(self._refresh_token, self._api_key)
-        if not jwt:
-            _LOGGER.error("Failed to refresh JWT")
-            return None
-
-        token = await fetch_firebase_download_token(bucket, image_path, jwt)
-        if not token:
-            _LOGGER.error("Failed to fetch download token")
-            return None
-
-        image_url = (
-            f"https://firebasestorage.googleapis.com/v0/b/{bucket}/o/"
-            f"{image_path}?alt=media&token={token}"
+        return await download_latest_snapshot(
+            self._device_id, self._refresh_token, self._api_key
         )
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(image_url) as resp:
-                    if resp.status == 200:
-                        return await resp.read()
-                    else:
-                        text = await resp.text()
-                        _LOGGER.error(f"Failed to fetch image: {resp.status}, Response: {text}")
-        except Exception as e:
-            _LOGGER.error(f"Exception fetching camera image: {e}")
-
-        return None

--- a/custom_components/coral_mylo/manifest.json
+++ b/custom_components/coral_mylo/manifest.json
@@ -4,7 +4,7 @@
     "documentation": "https://github.com/jakeyr/coral_mylo_ha",
     "dependencies": [],
     "codeowners": ["@jakeyr"],
-    "version": "1.0.1",
+    "version": "1.0.2",
     "config_flow": true,
     "issue_tracker": "https://github.com/jakeyr/coral_mylo_ha/issues",
     "requirements": ["aiohttp"],

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+import importlib.util
+import asyncio
+
+# Provide dummy aiohttp module before loading utils
+sys.modules['aiohttp'] = types.ModuleType('aiohttp')
+sys.modules['aiohttp'].ClientSession = None
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+utils_path = os.path.join(os.path.dirname(__file__), '..', 'custom_components', 'coral_mylo', 'utils.py')
+spec = importlib.util.spec_from_file_location('utils', utils_path)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+class FakeResponse:
+    def __init__(self, data=b'', status=200):
+        self._data = data
+        self.status = status
+    async def read(self):
+        return self._data
+    async def text(self):
+        return ''
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class FakeSession:
+    def __init__(self, response):
+        self._response = response
+    def get(self, *args, **kwargs):
+        return self._response
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+def test_download_latest_snapshot(monkeypatch):
+    response = FakeResponse(b'image')
+
+    async def fake_refresh(*args, **kwargs):
+        return 'jwt'
+
+    async def fake_token(*args, **kwargs):
+        return 'tok'
+
+    monkeypatch.setattr(utils, 'refresh_jwt', fake_refresh)
+    monkeypatch.setattr(utils, 'fetch_firebase_download_token', fake_token)
+    monkeypatch.setattr(
+        utils, 'aiohttp', types.SimpleNamespace(ClientSession=lambda: FakeSession(response))
+    )
+    data = asyncio.run(utils.download_latest_snapshot('id', 'r', 'k'))
+    assert data == b'image'
+
+def test_download_latest_snapshot_failure(monkeypatch):
+    async def fake_refresh(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(utils, 'refresh_jwt', fake_refresh)
+    data = asyncio.run(utils.download_latest_snapshot('id', 'r', 'k'))
+    assert data is None


### PR DESCRIPTION
## Summary
- add MyloSnapshotRefreshButton entity to manually refresh the latest snapshot
- share snapshot download logic with camera in new `download_latest_snapshot` util
- load the new button platform
- set integration version to 1.0.2
- document the new button entity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885ae35a150832ab8c9a923b7cd76be