### PR TITLE
Add release tagging workflow

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,35 @@
+name: Tag Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'custom_components/coral_mylo/manifest.json'
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: version
+        run: |
+          VERSION=$(jq -r '.version' custom_components/coral_mylo/manifest.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - id: check
+        run: |
+          git fetch --tags
+          if git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.version.outputs.version }}
+          commit: ${{ github.sha }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- trigger a tag and release when `manifest.json` changes on main

## Testing
- `pre-commit run --files .github/workflows/tag_release.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d03af2b0832aa748ece0c8ac9a07