### PR TITLE
Add camera refresh interval number

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ mylo_refresh_token: YOUR_REFRESH_TOKEN
 
 Save both files and restart Home Assistant.
 
+The integration automatically creates `number.mylo_refresh_interval` with a default of 300 seconds. Adjust this value to change how often snapshots refresh.
+
 ## Entities Created
 - `camera.mylo_camera_<id>` – shows the most recent snapshot taken by the MYLO.
 - `button.mylo_refresh_image` – capture a new snapshot on demand.
@@ -97,6 +99,7 @@ Save both files and restart Home Assistant.
 - `sensor.mylo_pool_status` – current pool status.
 - `sensor.mylo_battery` – MYLO battery level.
 - `sensor.mylo_system_ping` – last system ping timestamp.
+- `number.mylo_refresh_interval` – how often to automatically refresh snapshots (defaults to 300 seconds).
 
 The device ID becomes part of each entity's unique ID, ensuring separate MYLO units are differentiated if you add more than one.
 
@@ -104,6 +107,7 @@ The device ID becomes part of each entity's unique ID, ensuring separate MYLO un
 1. In Home Assistant open the **Overview** dashboard.
 2. Locate `button.mylo_refresh_image` and press it.
 3. The camera entity updates once the device reports the new snapshot is ready.
+   It also refreshes periodically based on `number.mylo_refresh_interval`.
 
 ## How It Works
 1. The integration connects to the MYLO's StatsD admin port (`8126`) to read gauge values. This also reveals the internal device ID used to construct camera and sensor entity IDs.
@@ -111,7 +115,7 @@ The device ID becomes part of each entity's unique ID, ensuring separate MYLO un
 3. With the JWT, it queries Firebase for a one‑time download token associated with `images/coral_<device_id>_last.jpg`.
 4. The final URL containing this token returns the latest snapshot, which Home Assistant exposes as the camera image.
 
-The integration maintains a persistent Firebase WebSocket connection. Image refresh commands and real-time sensor updates flow through this socket. Traditional StatsD polling is still used for metrics not provided over the WebSocket.
+The integration maintains a persistent Firebase WebSocket connection. Image refresh commands, including the periodic updates controlled by `number.mylo_refresh_interval`, and real-time sensor updates flow through this socket. Traditional StatsD polling is still used for metrics not provided over the WebSocket.
 
 ## Troubleshooting
 - **Camera unavailable** – ensure the API key is correct and the refresh token is still valid.

--- a/custom_components/coral_mylo/__init__.py
+++ b/custom_components/coral_mylo/__init__.py
@@ -40,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_id = None
 
     await hass.config_entries.async_forward_entry_setups(
-        entry, ["sensor", "camera", "button"]
+        entry, ["sensor", "camera", "button", "number"]
     )
     return True
 
@@ -49,7 +49,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     _LOGGER.debug("Unloading entry %s", entry.entry_id)
     unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, ["sensor", "camera", "button"]
+        entry, ["sensor", "camera", "button", "number"]
     )
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/coral_mylo/camera.py
+++ b/custom_components/coral_mylo/camera.py
@@ -6,7 +6,15 @@ from .utils import (
     discover_device_id_from_statsd,
     download_latest_snapshot,
 )
-from .const import CONF_IP_ADDRESS, CONF_REFRESH_TOKEN, CONF_API_KEY, DOMAIN
+from datetime import timedelta
+from homeassistant.helpers.event import async_track_time_interval
+from .const import (
+    CONF_IP_ADDRESS,
+    CONF_REFRESH_TOKEN,
+    CONF_API_KEY,
+    DOMAIN,
+    DEFAULT_REFRESH_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +37,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     ws = hass.data.get(DOMAIN, {}).get("ws", {}).get(entry.entry_id)
 
-    camera = MyloCamera(ip, refresh_token, api_key, device_id)
+    camera = MyloCamera(ip, refresh_token, api_key, device_id, ws)
     async_add_entities([camera])
     _LOGGER.debug("Camera entity created for MYLO %s", device_id)
 
@@ -49,12 +57,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class MyloCamera(Camera):
     """Camera entity that serves the latest snapshot from MYLO."""
 
-    def __init__(self, ip, refresh_token, api_key, device_id):
+    def __init__(self, ip, refresh_token, api_key, device_id, ws):
         super().__init__()
         self._ip = ip
         self._refresh_token = refresh_token
         self._api_key = api_key
         self._device_id = device_id
+        self._ws = ws
+        self._refresh_interval = DEFAULT_REFRESH_INTERVAL
+        self._unsub = None
         self._image = None
 
         self._attr_name = f"Mylo Camera {device_id}"
@@ -66,6 +77,49 @@ class MyloCamera(Camera):
             "model": "MYLO",
             "name": f"MYLO {device_id}",
         }
+
+    async def async_added_to_hass(self):
+        """Handle entity added to hass and start refresh task."""
+        await super().async_added_to_hass()
+        await self._start_timer()
+
+    async def async_will_remove_from_hass(self):
+        """Clean up refresh task when entity is removed."""
+        if self._unsub:
+            self._unsub()
+        await super().async_will_remove_from_hass()
+
+    async def _start_timer(self):
+        """(Re)start the periodic refresh timer."""
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+        if self._refresh_interval > 0:
+            self._unsub = async_track_time_interval(
+                self.hass,
+                self._scheduled_refresh,
+                timedelta(seconds=self._refresh_interval),
+            )
+
+    async def set_refresh_interval(self, interval: int) -> None:
+        """Update refresh interval and restart timer."""
+        self._refresh_interval = interval
+        if self.hass:
+            await self._start_timer()
+
+    async def _scheduled_refresh(self, now):
+        """Refresh the camera image on a timer."""
+        if not self._ws:
+            _LOGGER.error("WebSocket not available for MYLO refresh")
+            return
+        success = await self._ws.send_getimage()
+        if not success:
+            _LOGGER.error("MYLO did not report new image ready")
+            return
+        image = await download_latest_snapshot(
+            self._device_id, self._refresh_token, self._api_key
+        )
+        self.update_image(image)
 
     async def async_camera_image(self, **kwargs):
         """Return image from MYLO, downloading if necessary."""
@@ -83,3 +137,7 @@ class MyloCamera(Camera):
             self._image = image
             if self.hass:
                 self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self):
+        return {"refresh_interval": self._refresh_interval}

--- a/custom_components/coral_mylo/const.py
+++ b/custom_components/coral_mylo/const.py
@@ -3,3 +3,4 @@ DOMAIN = "coral_mylo"
 CONF_IP_ADDRESS = "ip"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_API_KEY = "api_key"
+DEFAULT_REFRESH_INTERVAL = 300

--- a/custom_components/coral_mylo/manifest.json
+++ b/custom_components/coral_mylo/manifest.json
@@ -4,7 +4,7 @@
     "documentation": "https://github.com/jakeyr/coral_mylo_ha",
     "dependencies": [],
     "codeowners": ["@jakeyr"],
-    "version": "1.1.1",
+    "version": "1.1.3",
     "config_flow": true,
     "issue_tracker": "https://github.com/jakeyr/coral_mylo_ha/issues",
     "requirements": ["aiohttp"],

--- a/custom_components/coral_mylo/number.py
+++ b/custom_components/coral_mylo/number.py
@@ -1,0 +1,48 @@
+import logging
+from homeassistant.components.number import NumberEntity
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from .const import DOMAIN, DEFAULT_REFRESH_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up number entity for refresh interval."""
+    camera = hass.data.get(DOMAIN, {}).get("cameras", {}).get(entry.entry_id)
+    if not camera:
+        _LOGGER.error("Camera entity not available for number setup")
+        return
+    async_add_entities([MyloRefreshIntervalNumber(camera)])
+
+class MyloRefreshIntervalNumber(RestoreEntity, NumberEntity):
+    """Number entity to control automatic refresh interval."""
+
+    def __init__(self, camera):
+        self._camera = camera
+        device_id = camera._device_id
+        self._attr_name = "Mylo Refresh Interval"
+        self._attr_unique_id = f"mylo_refresh_interval_{device_id}"
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = 3600
+        self._attr_native_step = 10
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_info = camera.device_info
+        self._value = DEFAULT_REFRESH_INTERVAL
+
+    @property
+    def native_value(self):
+        return self._value
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        if (state := await self.async_get_last_state()) is not None:
+            try:
+                self._value = int(float(state.state))
+            except ValueError:
+                self._value = DEFAULT_REFRESH_INTERVAL
+            await self._camera.set_refresh_interval(self._value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        self._value = int(value)
+        await self._camera.set_refresh_interval(self._value)
+

--- a/custom_components/coral_mylo/number.py
+++ b/custom_components/coral_mylo/number.py
@@ -6,6 +6,7 @@ from .const import DOMAIN, DEFAULT_REFRESH_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up number entity for refresh interval."""
     camera = hass.data.get(DOMAIN, {}).get("cameras", {}).get(entry.entry_id)
@@ -13,6 +14,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         _LOGGER.error("Camera entity not available for number setup")
         return
     async_add_entities([MyloRefreshIntervalNumber(camera)])
+
 
 class MyloRefreshIntervalNumber(RestoreEntity, NumberEntity):
     """Number entity to control automatic refresh interval."""
@@ -45,4 +47,3 @@ class MyloRefreshIntervalNumber(RestoreEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         self._value = int(value)
         await self._camera.set_refresh_interval(self._value)
-


### PR DESCRIPTION
## Summary
- set up a new `number.mylo_refresh_interval` entity
- schedule camera updates based on that value
- remove setup option for refresh interval
- mark the number entity as configuration

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885cd4709cc832a9a6ccd8360b59eda