### PR TITLE
fix release workflow input

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           tag: ${{ steps.version.outputs.version }}
           commit: ${{ github.sha }}
-          generate_release_notes: true
+          generateReleaseNotes: true


### PR DESCRIPTION
## Summary
- fix release workflow input name to generate release notes with `ncipollo/release-action`

## Testing
- `pre-commit run --files .github/workflows/tag_release.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688da554c504832aa0ff64440ad02080