### PR TITLE
Fix SensorDeviceClass import path

### DIFF
--- a/custom_components/coral_mylo/sensor.py
+++ b/custom_components/coral_mylo/sensor.py
@@ -2,11 +2,10 @@
 
 import logging
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
-    SensorDeviceClass,
     UnitOfLength,
     UnitOfSpeed,
     UnitOfTemperature,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -66,6 +66,7 @@ const_module.SensorDeviceClass = types.SimpleNamespace(
     DATE="date",
 )
 sys.modules["homeassistant.const"] = const_module
+sensor_module.SensorDeviceClass = const_module.SensorDeviceClass
 
 # Ensure packages exist without executing integration __init__
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- fix SensorDeviceClass import for compatibility with new Home Assistant
- adjust tests for updated import location

## Testing
- `pre-commit run --files custom_components/coral_mylo/sensor.py tests/test_sensor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688db9e7ef04832aa08ac3770c84e651