### PR TITLE
feat: expose additional statsd sensors

### DIFF
--- a/custom_components/coral_mylo/sensor.py
+++ b/custom_components/coral_mylo/sensor.py
@@ -8,8 +8,10 @@ from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
     UnitOfLength,
+    UnitOfPressure,
     UnitOfSpeed,
     UnitOfTemperature,
+    UnitOfTime,
 )
 
 from .utils import (
@@ -52,6 +54,18 @@ async def async_setup_entry(hass, entry, async_add_entities):
             SensorDeviceClass.DISTANCE,
         ),
         (
+            "water.pressure_sensor",
+            "Water Pressure",
+            UnitOfPressure.MBAR,
+            SensorDeviceClass.PRESSURE,
+        ),
+        (
+            "water.cloudiness",
+            "Water Cloudiness",
+            PERCENTAGE,
+            None,
+        ),
+        (
             "weather.wind_kph",
             "Wind Speed",
             UnitOfSpeed.KILOMETERS_PER_HOUR,
@@ -62,6 +76,60 @@ async def async_setup_entry(hass, entry, async_add_entities):
             "Air Quality PM2.5",
             CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             SensorDeviceClass.PM25,
+        ),
+        (
+            "weather.aq_pm10",
+            "Air Quality PM10",
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            SensorDeviceClass.PM10,
+        ),
+        (
+            "weather.precip_mm.count",
+            "Precipitation",
+            UnitOfLength.MILLIMETERS,
+            SensorDeviceClass.PRECIPITATION,
+        ),
+        (
+            "weather.vis_km",
+            "Visibility",
+            UnitOfLength.KILOMETERS,
+            SensorDeviceClass.DISTANCE,
+        ),
+        (
+            "weather.pressure_mb",
+            "Atmospheric Pressure",
+            UnitOfPressure.MBAR,
+            SensorDeviceClass.PRESSURE,
+        ),
+        (
+            "darkness",
+            "Darkness",
+            PERCENTAGE,
+            None,
+        ),
+        (
+            "manager.alert_level",
+            "Alert Level",
+            None,
+            None,
+        ),
+        (
+            "pool.used.count",
+            "Pool Used Count",
+            None,
+            None,
+        ),
+        (
+            "robot.count",
+            "Robot Count",
+            None,
+            None,
+        ),
+        (
+            "statsd.timestamp_lag",
+            "StatsD Timestamp Lag",
+            UnitOfTime.SECONDS,
+            SensorDeviceClass.DURATION,
         ),
     ]
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -55,8 +55,14 @@ sys.modules["homeassistant.components.sensor"] = sensor_module
 
 const_module = types.ModuleType("homeassistant.const")
 const_module.UnitOfTemperature = types.SimpleNamespace(CELSIUS="°C")
-const_module.UnitOfLength = types.SimpleNamespace(CENTIMETERS="cm")
+const_module.UnitOfLength = types.SimpleNamespace(
+    CENTIMETERS="cm",
+    KILOMETERS="km",
+    MILLIMETERS="mm",
+)
 const_module.UnitOfSpeed = types.SimpleNamespace(KILOMETERS_PER_HOUR="km/h")
+const_module.UnitOfPressure = types.SimpleNamespace(MBAR="mbar")
+const_module.UnitOfTime = types.SimpleNamespace(SECONDS="s")
 const_module.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER = "µg/m³"
 const_module.PERCENTAGE = "%"
 const_module.SensorDeviceClass = types.SimpleNamespace(
@@ -64,6 +70,10 @@ const_module.SensorDeviceClass = types.SimpleNamespace(
     DISTANCE="distance",
     WIND_SPEED="wind_speed",
     PM25="pm25",
+    PM10="pm10",
+    PRESSURE="pressure",
+    PRECIPITATION="precipitation",
+    DURATION="duration",
     BATTERY="battery",
     DATE="date",
 )
@@ -121,6 +131,49 @@ def test_device_classes_assigned():
     )
     assert wind.device_class == const_module.SensorDeviceClass.WIND_SPEED
     assert wind.native_unit_of_measurement == "km/h"
+
+    pressure = sensor.MyloSensor(
+        "1.2.3.4",
+        "dev1",
+        "weather.pressure_mb",
+        "Atmospheric Pressure",
+        const_module.UnitOfPressure.MBAR,
+        const_module.SensorDeviceClass.PRESSURE,
+    )
+    assert pressure.device_class == const_module.SensorDeviceClass.PRESSURE
+    assert pressure.native_unit_of_measurement == "mbar"
+
+    pm10 = sensor.MyloSensor(
+        "1.2.3.4",
+        "dev1",
+        "weather.aq_pm10",
+        "Air Quality PM10",
+        const_module.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        const_module.SensorDeviceClass.PM10,
+    )
+    assert pm10.device_class == const_module.SensorDeviceClass.PM10
+
+    precip = sensor.MyloSensor(
+        "1.2.3.4",
+        "dev1",
+        "weather.precip_mm.count",
+        "Precipitation",
+        const_module.UnitOfLength.MILLIMETERS,
+        const_module.SensorDeviceClass.PRECIPITATION,
+    )
+    assert precip.device_class == const_module.SensorDeviceClass.PRECIPITATION
+    assert precip.native_unit_of_measurement == "mm"
+
+    lag = sensor.MyloSensor(
+        "1.2.3.4",
+        "dev1",
+        "statsd.timestamp_lag",
+        "StatsD Timestamp Lag",
+        const_module.UnitOfTime.SECONDS,
+        const_module.SensorDeviceClass.DURATION,
+    )
+    assert lag.device_class == const_module.SensorDeviceClass.DURATION
+    assert lag.native_unit_of_measurement == "s"
 
     cpu = sensor.MyloRealtimeSensor(
         "dev1",


### PR DESCRIPTION
## Summary
- expose new gauge metrics like water pressure, precipitation, visibility, and alert levels
- expand test stubs and coverage for new device classes

## Testing
- `pre-commit run --files custom_components/coral_mylo/sensor.py tests/test_sensor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689188e12918832a934e7a828a7104c3