### PR TITLE
feat: parse memory usage

### DIFF
--- a/custom_components/coral_mylo/sensor.py
+++ b/custom_components/coral_mylo/sensor.py
@@ -202,7 +202,11 @@ class MyloSensor(SensorEntity):
 
     async def async_update(self):
         """Fetch latest value from the MYLO StatsD server."""
-        full_key = f"coral.{self._device_id}.{self._metric}"
+        full_key = (
+            self._metric
+            if self._metric.startswith("statsd.")
+            else f"coral.{self._device_id}.{self._metric}"
+        )
         _LOGGER.debug("Querying gauge %s on %s", full_key, self._ip)
         gauges = await self.hass.async_add_executor_job(
             read_gauges_from_statsd, self._ip

--- a/custom_components/coral_mylo/utils.py
+++ b/custom_components/coral_mylo/utils.py
@@ -6,6 +6,7 @@ import asyncio
 import time
 import json
 import aiohttp
+import re
 
 _LOGGER = logging.getLogger(__name__)
 STATS_PORT = 8126
@@ -46,6 +47,37 @@ def get_statsd_gauge_value(ip, key):
     """Convenience helper to fetch a single StatsD gauge value."""
     gauges = read_gauges_from_statsd(ip)
     return gauges.get(key)
+
+
+def parse_memory_usage(value):
+    """Parse memory usage string into its components.
+
+    Expected format: "used: 78.0%, available: 873MB, swap is at 41%".
+
+    Returns a dictionary with keys:
+    - ``used_percent`` (float)
+    - ``available_mb`` (int)
+    - ``swap_percent`` (float)
+    or ``None`` if parsing fails.
+    """
+
+    if not isinstance(value, str):
+        return None
+
+    pattern = (
+        r"used:\s*(?P<used>\d+(?:\.\d+)?)%,\s*"
+        r"available:\s*(?P<available>\d+)MB,\s*"
+        r"swap is at\s*(?P<swap>\d+(?:\.\d+)?)%"
+    )
+    match = re.search(pattern, value)
+    if not match:
+        return None
+
+    return {
+        "used_percent": float(match.group("used")),
+        "available_mb": int(match.group("available")),
+        "swap_percent": float(match.group("swap")),
+    }
 
 
 async def refresh_jwt(refresh_token, api_key):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -49,6 +49,10 @@ class SensorEntity(Entity):
     def device_class(self):
         return getattr(self, "_attr_device_class", None)
 
+    @property
+    def extra_state_attributes(self):
+        return getattr(self, "_attr_extra_state_attributes", None)
+
 
 sensor_module.SensorEntity = SensorEntity
 sys.modules["homeassistant.components.sensor"] = sensor_module
@@ -213,3 +217,17 @@ def test_last_off_notification_parses_date():
 
     assert isinstance(last_off.native_value, date)
     assert last_off.native_value == date(2025, 7, 29)
+
+
+def test_memory_usage_parses_components():
+    """Ensure memory usage string is parsed into sub values."""
+
+    memory = sensor.MyloRealtimeSensor("dev1", "Memory Usage", "/status/memory", None)
+
+    asyncio.run(memory.update_from_ws("used: 78.0%, available: 873MB, swap is at 41%"))
+
+    assert memory.native_value == 78.0
+    assert memory.extra_state_attributes == {
+        "available_mb": 873,
+        "swap_percent": 41.0,
+    }


### PR DESCRIPTION
## Summary
- parse memory usage string into used/available/swap values
- expose memory usage metrics and attributes via realtime sensor
- test memory usage parsing

## Testing
- `pre-commit run --files custom_components/coral_mylo/utils.py custom_components/coral_mylo/sensor.py tests/test_sensor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689193fe375c832aad7171cf9ff7a4dd