### PR TITLE
docs: update README for new sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,33 @@ Integrate your **Coral MYLO Pool Camera** (also known as SmartPool MYLO) with Ho
 ## Features
 - **Camera** entity displaying the most recent MYLO image
 - **Button** to capture a fresh snapshot via Firebase
-- **Sensors** for key pool and weather values collected by MYLO:
+- **Sensors** for pool, weather, and system statistics collected by MYLO:
   - Water temperature (`°C`)
   - Water level (`cm`)
+  - Water pressure (`mbar`)
+  - Water cloudiness (`%`)
   - Wind speed (`km/h`)
   - Air quality PM2.5 (`µg/m³`)
+  - Air quality PM10 (`µg/m³`)
+  - Precipitation (`mm`)
+  - Visibility (`km`)
+  - Atmospheric pressure (`mbar`)
+  - Darkness (`%`)
+  - Alert level
+  - Pool used count
+  - Robot count
+  - StatsD timestamp lag (`s`)
   - Cloudiness status
-  - Health status
   - Pool status
   - Battery level
   - System ping
+  - CPU temperature (`°C`)
+  - GPU temperature (`°C`)
+  - Memory usage (`%` used with attributes)
+  - Update status
+  - Last off notification (date)
+- **Binary sensors** for device health and log events (person detected in pool or near the pool)
+- **Events**: each device log entry is emitted on the Home Assistant bus as `coral_mylo_log`
 
 ## Requirements
 - A running Home Assistant instance (Core or OS)
@@ -92,13 +109,31 @@ The integration automatically creates `number.mylo_refresh_interval` with a defa
 - `button.mylo_refresh_image` – capture a new snapshot on demand.
 - `sensor.mylo_water_temperature` – pool water temperature.
 - `sensor.mylo_water_level` – measured distance from camera to water surface.
+- `sensor.mylo_water_pressure` – water pressure.
+- `sensor.mylo_water_cloudiness` – water cloudiness percentage.
 - `sensor.mylo_wind_speed` – outdoor wind speed near the pool.
 - `sensor.mylo_air_quality_pm2_5` – particulate matter reading (PM2.5).
-- `sensor.mylo_cloudiness` – pool water cloudiness.
-- `sensor.mylo_health` – overall device health.
+- `sensor.mylo_air_quality_pm10` – particulate matter reading (PM10).
+- `sensor.mylo_precipitation` – recent precipitation.
+- `sensor.mylo_visibility` – visibility distance.
+- `sensor.mylo_atmospheric_pressure` – atmospheric pressure.
+- `sensor.mylo_darkness` – ambient darkness level.
+- `sensor.mylo_alert_level` – current alert level.
+- `sensor.mylo_pool_used_count` – number of times the pool was used.
+- `sensor.mylo_robot_count` – number of robot activations.
+- `sensor.mylo_statsd_timestamp_lag` – lag between MYLO and StatsD timestamps.
+- `sensor.mylo_cloudiness` – status cloudiness reading.
 - `sensor.mylo_pool_status` – current pool status.
 - `sensor.mylo_battery` – MYLO battery level.
 - `sensor.mylo_system_ping` – last system ping timestamp.
+- `sensor.mylo_cpu_temperature` – CPU temperature.
+- `sensor.mylo_gpu_temperature` – GPU temperature.
+- `sensor.mylo_memory_usage` – percent of memory used with extra attributes.
+- `sensor.mylo_update_status` – current update status.
+- `sensor.mylo_last_off_notification` – date the device last reported being off.
+- `binary_sensor.mylo_health` – overall device health.
+- `binary_sensor.mylo_person_detected_in_pool` – turns on briefly when a person is detected in the pool.
+- `binary_sensor.mylo_someone_detected_near_pool` – turns on briefly when someone is detected near the pool.
 - `number.mylo_refresh_interval` – how often to automatically refresh snapshots (defaults to 300 seconds).
 
 The device ID becomes part of each entity's unique ID, ensuring separate MYLO units are differentiated if you add more than one.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Coral Mylo Home Assistant Integration
 
-Integrate your **Coral MYLO Pool Camera** (also known as SmartPool MYLO) with Home Assistant. The integration exposes the latest pool snapshot as a camera entity and provides several live sensors from the device's StatsD interface.
+Integrate your **Coral MYLO Pool Camera** with Home Assistant. The integration exposes the latest pool snapshot as a camera entity and provides live sensors sourced from a mix of the device's StatsD service and Firebase WebSocket updates.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jakeyr&repository=coral_mylo_ha&category=integration)
 
 ## Features
 - **Camera** entity displaying the most recent MYLO image
 - **Button** to capture a fresh snapshot via Firebase
-- **Sensors** for pool, weather, and system statistics collected by MYLO:
+- **Sensors** for pool, weather, and system statistics collected from StatsD and real-time WebSocket updates:
   - Water temperature (`°C`)
   - Water level (`cm`)
   - Water pressure (`mbar`)
@@ -23,7 +23,7 @@ Integrate your **Coral MYLO Pool Camera** (also known as SmartPool MYLO) with Ho
   - Pool used count
   - Robot count
   - StatsD timestamp lag (`s`)
-  - Cloudiness status
+  - Cloudiness (`%`)
   - Pool status
   - Battery level
   - System ping
@@ -122,7 +122,7 @@ The integration automatically creates `number.mylo_refresh_interval` with a defa
 - `sensor.mylo_pool_used_count` – number of times the pool was used.
 - `sensor.mylo_robot_count` – number of robot activations.
 - `sensor.mylo_statsd_timestamp_lag` – lag between MYLO and StatsD timestamps.
-- `sensor.mylo_cloudiness` – status cloudiness reading.
+- `sensor.mylo_cloudiness` – cloudiness percentage.
 - `sensor.mylo_pool_status` – current pool status.
 - `sensor.mylo_battery` – MYLO battery level.
 - `sensor.mylo_system_ping` – last system ping timestamp.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Integrate your **Coral MYLO Pool Camera** with Home Assistant. The integration e
   - Memory usage (`%` used with attributes)
   - Update status
   - Last off notification (date)
-- **Binary sensors** for device health and log events (person detected in pool or near the pool)
+- **Binary sensors** for device health and log-triggered presence alerts in and around the pool (auto-reset after a short period)
 - **Events**: each device log entry is emitted on the Home Assistant bus as `coral_mylo_log`
 
 ## Requirements
@@ -132,8 +132,8 @@ The integration automatically creates `number.mylo_refresh_interval` with a defa
 - `sensor.mylo_update_status` – current update status.
 - `sensor.mylo_last_off_notification` – date the device last reported being off.
 - `binary_sensor.mylo_health` – overall device health.
-- `binary_sensor.mylo_person_detected_in_pool` – turns on briefly when a person is detected in the pool.
-- `binary_sensor.mylo_someone_detected_near_pool` – turns on briefly when someone is detected near the pool.
+- `binary_sensor.mylo_person_detected_in_pool` – switches on for about two minutes when the device log reports a person in the pool.
+- `binary_sensor.mylo_someone_detected_near_pool` – switches on for about two minutes when the device log reports someone near the pool.
 - `number.mylo_refresh_interval` – how often to automatically refresh snapshots (defaults to 300 seconds).
 
 The device ID becomes part of each entity's unique ID, ensuring separate MYLO units are differentiated if you add more than one.

--- a/custom_components/coral_mylo/manifest.json
+++ b/custom_components/coral_mylo/manifest.json
@@ -4,7 +4,7 @@
     "documentation": "https://github.com/jakeyr/coral_mylo_ha",
     "dependencies": [],
     "codeowners": ["@jakeyr"],
-    "version": "1.1.9",
+    "version": "1.1.10",
     "config_flow": true,
     "issue_tracker": "https://github.com/jakeyr/coral_mylo_ha/issues",
     "requirements": ["aiohttp"],


### PR DESCRIPTION
## Summary
- document all new pool, weather, and system sensors
- mention binary sensors and `coral_mylo_log` event
- expand entity list with new sensors and binary sensors

## Testing
- `pre-commit run --files README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689242205b2c832a8a9d956b7d35d3c3