### PR TITLE
Handle dict-based state logs by timestamp

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -362,3 +362,18 @@ def test_pool_state_sensor_handles_list():
         )
     )
     assert ps.native_value == "in_pool"
+
+
+def test_pool_state_sensor_handles_dict_of_entries():
+    """When receiving a dict of entries, the newest timestamp is used."""
+
+    ps = sensor.MyloPoolStateSensor("dev1", None)
+    asyncio.run(
+        ps.update_from_ws(
+            {
+                "0": {"state": 1, "timestamp": "2024-01-01"},
+                "1": {"state": 3, "timestamp": "2024-01-02"},
+            }
+        )
+    )
+    assert ps.native_value == "in_pool"


### PR DESCRIPTION
## Summary
- correctly select latest pool state entry based on timestamp when websocket sends a dict
- cover dict-based state logs in tests
- simplify timestamp comparison using `max` and `datetime.fromisoformat`

## Testing
- `pre-commit run --files custom_components/coral_mylo/sensor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892e43662e0832aaa4d3cafd1161829